### PR TITLE
Fix issue #2 - dlopen error on Linux

### DIFF
--- a/src/main/java/com/quantego/clp/NativeLoader.java
+++ b/src/main/java/com/quantego/clp/NativeLoader.java
@@ -33,6 +33,7 @@ class NativeLoader {
         } else if (osName.startsWith("linux")) {
         	path = library+"/linux64/";
         	libs = new String[]{"libCoinUtils.so.3","libClp.so"};
+            BridJ.addNativeLibraryDependencies("Clp", "CoinUtils");
         } else {
             throw new UnsupportedOperationException("Platform " + osName + ":" + osArch + " not supported");
         }

--- a/src/main/java/com/quantego/clp/NativeLoader.java
+++ b/src/main/java/com/quantego/clp/NativeLoader.java
@@ -1,5 +1,6 @@
 package com.quantego.clp;
 
+import org.bridj.BridJ;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;

--- a/src/main/java/com/quantego/clp/NativeLoader.java
+++ b/src/main/java/com/quantego/clp/NativeLoader.java
@@ -27,16 +27,9 @@ class NativeLoader {
         if (osName.startsWith("mac")) {
         	path = library+"/darwin/";
         	libs = new String[]{"libCoinUtils.3.dylib","libClp.dylib"};
-        } else if (osName.startsWith("win")) {
-        	if (osArch.contains("64")) {
-        		path = library+"/win64/";
-            	libs = new String[]{"libgcc_s_seh_64-1.dll","libstdc++_64-6.dll","libCoinUtils-3.dll","Clp.dll",};
-            	for (String lib : libs) 
-            		loadLibrary(tempDir,path,lib);
-        	}
-            else {
-                throw new UnsupportedOperationException("Platform " + osName + ":" + osArch + " notsupported");
-            }
+        } else if (osName.startsWith("win") && osArch.contains("64")) {
+        	path = library+"/win64/";
+            libs = new String[]{"libgcc_s_seh_64-1.dll","libstdc++_64-6.dll","libCoinUtils-3.dll","Clp.dll",};
         } else if (osName.startsWith("linux")) {
         	path = library+"/linux64/";
         	libs = new String[]{"libCoinUtils.so.3","libClp.so"};

--- a/src/main/java/com/quantego/clp/NativeLoader.java
+++ b/src/main/java/com/quantego/clp/NativeLoader.java
@@ -18,6 +18,8 @@ class NativeLoader {
 
 	static void load() {
 		File tempDir = createTempDir(prefix);
+        BridJ.addLibraryPath(tempDir.getAbsolutePath());
+
 		String osArch = System.getProperty("os.arch");
         String osName = System.getProperty("os.name").toLowerCase();
         String path;
@@ -25,14 +27,12 @@ class NativeLoader {
         if (osName.startsWith("mac")) {
         	path = library+"/darwin/";
         	libs = new String[]{"libCoinUtils.3.dylib","libClp.dylib"};
-            System.setProperty("java.library.path", System.getProperty("java.library.path")+":"+tempDir.getAbsolutePath());
         } else if (osName.startsWith("win")) {
         	if (osArch.contains("64")) {
         		path = library+"/win64/";
             	libs = new String[]{"libgcc_s_seh_64-1.dll","libstdc++_64-6.dll","libCoinUtils-3.dll","Clp.dll",};
             	for (String lib : libs) 
             		loadLibrary(tempDir,path,lib);
-                System.setProperty("java.library.path", System.getProperty("java.library.path")+";"+tempDir.getAbsolutePath());
         	}
             else {
                 throw new UnsupportedOperationException("Platform " + osName + ":" + osArch + " notsupported");
@@ -40,8 +40,6 @@ class NativeLoader {
         } else if (osName.startsWith("linux")) {
         	path = library+"/linux64/";
         	libs = new String[]{"libCoinUtils.so.3","libClp.so"};
-            System.setProperty("java.library.path", System.getProperty("java.library.path")+":"+tempDir.getAbsolutePath());
-
         } else {
             throw new UnsupportedOperationException("Platform " + osName + ":" + osArch + " not supported");
         }


### PR DESCRIPTION
This fixes the issue by telling BridJ to look for CoinUtils before loading Clp. I'm not sure why this is necessary for Linux systems, but not Windows and Mac.

Also cleaned up the NativeLoader code a bit. Tested on clean (i.e. without clp installed) Windows, Mac and Ubuntu.
