### PR TITLE
Clp is now autocloseable, since finalize is deprecated and performanc…

### DIFF
--- a/src/main/java/com/quantego/clp/CLP.java
+++ b/src/main/java/com/quantego/clp/CLP.java
@@ -33,7 +33,7 @@ import java.util.Map;
  * @author Nils Loehndorf
  *
  */
-public class CLP {
+public class CLP implements AutoCloseable {
 	
 	static {
 		NativeLoader.load();
@@ -68,6 +68,8 @@ public class CLP {
 	ColBuffer _colBuffer = new ColBuffer();
 	RowBuffer _rowBuffer = new RowBuffer();
 	QuadraticObjective _qobj;
+
+	boolean _isClosed = false;
 	
 	/**
 	 * Create an new model instance.
@@ -807,12 +809,19 @@ public class CLP {
 	
 	@Override
 	public void finalize() {
-		CLPNative.clpDeleteModel(_model);
-		CLPNative.clpSolveDelete(_solve); 
+		close();
 	}
-	
-	
-	
+
+	@Override
+	public void close() {
+		if(!_isClosed) {
+			CLPNative.clpDeleteModel(_model);
+			CLPNative.clpSolveDelete(_solve);
+			_isClosed = true;
+		}
+	}
+
+
 	private int[] toIntArray(List<Integer> ints) {
 		int[] ar = new int[ints.size()];
 		int i=0;


### PR DESCRIPTION
…e bottleneck. Keeping finalize as a fallback option.

When spamming many CLP models, the JVM finalizer thread is not able to catch up. Finalize method is considered deprecated and has no guarantees. Leading to memory leaks during computation.  

AutoCloseable option provides an explicit method to free native memory. The finalizer thread has little to do and hence no memory leaks occur during computation. 

Finalize method should be removed in future releases, forcing a user to explicitly release native memory or use try-wtih-resources block.  